### PR TITLE
Chore: Vulnerability remediation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,6 +95,12 @@ var rewriteVersion = if(project.hasProperty("releasing")) {
 }
 
 dependencies {
+    constraints {
+        implementation("com.fasterxml.woodstox:woodstox-core:6.5.0") {
+            because("Versions <= 6.3.1 contain vulnerabilities")
+        }
+    }
+
     implementation("org.openrewrite:rewrite-yaml:$rewriteVersion")
     implementation("org.openrewrite:rewrite-java:${rewriteVersion}")
     implementation("org.openrewrite:rewrite-xml:${rewriteVersion}")

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2023-02-27Z">
-        <notes><![CDATA[
-        file name: woodstox-core-6.3.1.jar
-        Severity: HIGH
-        False positive. We do not use woodstox and it will be updated with the next spring cloud
-        dependencies.
-    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.woodstox/woodstox\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2022-40152</vulnerabilityName>
-    </suppress>
     <suppress>
         <notes><![CDATA[
             file name: snakeyaml-1.33.jar
@@ -19,5 +9,6 @@
         <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
         <cve>CVE-2022-1471</cve>
         <cve>CVE-2022-3064</cve>
+        <cve>CVE-2021-4235</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
Changes:

- Added tag for CVE-2021-4235 to snakeyaml suppression.
- Pinned com.fasterxml.woodstox:woodstox-core to non-vulnerable 6.5.0