### PR TITLE
Drop Terraform dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
     implementation("org.openrewrite:rewrite-maven")
     implementation("org.openrewrite.recipe:rewrite-migrate-java:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-static-analysis:$rewriteVersion")
-    implementation("org.openrewrite.recipe:rewrite-terraform:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-testing-frameworks:$rewriteVersion")
 
     testImplementation("org.openrewrite:rewrite-test")

--- a/src/main/resources/META-INF/rewrite/radar.yml
+++ b/src/main/resources/META-INF/rewrite/radar.yml
@@ -55,15 +55,3 @@ tags:
 recipeList:
   - org.openrewrite.maven.cleanup.DependencyManagementDependencyRequiresVersion
   - org.openrewrite.java.RemoveUnusedImports
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.recommendations.InfrastructureAsCode
-displayName: Infrastructure As Code
-description: Used for Infrastructure As Code metric on moderne radar.
-tags:
-  - health check
-  - radar
-recipeList:
-  - 'org.openrewrite.terraform.aws.AWSBestPractices'
-  - 'org.openrewrite.terraform.azure.AzureBestPractices'
-  - 'org.openrewrite.terraform.gcp.GCPBestPractices'


### PR DESCRIPTION
## What's your motivation?
- https://github.com/openrewrite/rewrite-recipe-bom/pull/36#issuecomment-2593383428

## Anything in particular you'd like reviewers to focus on?
Perhaps we can drop all of the "radar.yml" recipes?
Those are for a feature since replaced by DevCenter.